### PR TITLE
Add offset to results

### DIFF
--- a/pythonx/completor_necosyntax.py
+++ b/pythonx/completor_necosyntax.py
@@ -28,7 +28,7 @@ class Necosyntax(Completor):
         return candidates
 
     def parse(self, base):
-        if not self.ft or not base:
+        if not self.ft or not base or base.endswith((' ', '\t')):
             return []
 
         if self.ft not in _cache:
@@ -42,10 +42,8 @@ class Necosyntax(Completor):
                       if item['word'].startswith(token.encode('utf-8'))]
         logger.info(candidates)
 
-        index = token.rfind(base)
-        if index > 0:
-            prefix = len(token[:index])
-            for c in candidates:
-                c['abbr'] = c['word']
-                c['word'] = c['word'][prefix:]
+        offset = len(self.input_data) - len(token)
+        for c in candidates:
+            c['abbr'] = c['word']
+            c['offset'] = offset
         return candidates


### PR DESCRIPTION
Thank you for making the plugin.

I got the following error, so I fixed it for the same as https://github.com/maralla/completor-neosnippet/commit/472538eef308ca73eb38d8e50807253744821953.

```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "C:\Users\tamago324\vimfiles\plugged\completor.vim\pythonx\completor\api.py", line 14, in wrapper
    return func(vim.bindeval('a:'))
  File "C:\Users\tamago324\vimfiles\plugged\completor.vim\pythonx\completor\api.py", line 82, in on_stream
    c.handle_stream(name, args['action'], args['msg'])
  File "C:\Users\tamago324\vimfiles\plugged\completor.vim\pythonx\completor\__init__.py", line 276, in handle_stream
    res = self.on_stream(action, msg)
  File "C:\Users\tamago324\vimfiles\plugged\completor.vim\pythonx\completor\__init__.py", line 264, in on_stream
    return self.on_data(action, data)
  File "C:\Users\tamago324\vimfiles\plugged\completor.vim\pythonx\completor\__init__.py", line 295, in on_data
    return self._do_complete(data)
  File "C:\Users\tamago324\vimfiles\plugged\completor.vim\pythonx\completor\__init__.py", line 242, in _do_complete
    ret.extend(common.parse(self.input_data)[:COMMON_LIMIT])
  File "C:\Users\tamago324\vimfiles\plugged\completor.vim\pythonx\completers\common\__init__.py", line 63, in parse
    *[self.completions(n, base) for n in self.hooks]))
  File "C:\Users\tamago324\vimfiles\plugged\completor.vim\pythonx\completers\common\__init__.py", line 63, in <listcomp>
    *[self.completions(n, base) for n in self.hooks]))
  File "C:\Users\tamago324\vimfiles\plugged\completor.vim\pythonx\completers\common\__init__.py", line 53, in completions
    items['offset'] = self._start_column
TypeError: list indices must be integers or slices, not str
```

Thank you!